### PR TITLE
Supervisor 3.2.0 compatibility

### DIFF
--- a/scripts/skynet
+++ b/scripts/skynet
@@ -185,13 +185,13 @@ def full_name(proc):
 def get_server_conf():
     """ returns supervisor server config """
     client = options.ServerOptions()
-    client.realize(raise_getopt_errs=False, args=[])
+    client.realize(args=[])
     return client
 
 def get_svp():
     """ returns supervisor xmlrpc proxy """
     client = options.ClientOptions()
-    client.realize(raise_getopt_errs=False, args=[])
+    client.realize(args=[])
     return client.getServerProxy()
 
 def remove_nonexistent_groups(group_set):


### PR DESCRIPTION
Don't pass raise_getopt_errs, which got removed from Option.realize in
Supervisor commit e92941c32d7d33f6d889afb1f01d6b4c2c99d71b
